### PR TITLE
新增 seed 腳本以初始化資料庫，並更新 package.json 中的相關腳本

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only -r tsconfig-paths/register src/app.ts",
     "build": "tsc",
-    "start": "node dist/app.js"
+    "start": "node dist/app.js",
+    "seed": "ts-node prisma/seed.ts"
   },
   "keywords": [],
   "author": "",
@@ -26,7 +27,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
-    "@types/node": "^24.0.13",
+    "@types/node": "^24.1.0",
     "@types/papaparse": "^5.3.16",
     "prisma": "^6.12.0",
     "ts-node": "^10.9.2",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,25 @@
+// prisma/seed.ts
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.device.deleteMany();
+  await prisma.species.deleteMany();
+  await prisma.appearance_record.deleteMany();
+
+  await prisma.device.createMany({
+    data: Array.from({ length: 10 }, (_, i) => ({
+      device_id: i + 1,
+      device_name: `Device ${i + 1}`,
+    })),
+  });
+
+  await prisma.species.create({
+    data: {
+      species_name: '雞',
+    }
+  });
+}
+main()
+  .then(() => prisma.$disconnect())
+  .catch((e) => { console.error(e); prisma.$disconnect(); process.exit(1); });


### PR DESCRIPTION
## Summary by Sourcery

Add a database seed script using Prisma and update package.json scripts to include the new seeding command

New Features:
- Introduce a Prisma seed script to reset and populate the database

Enhancements:
- Add a 'seed' command in package.json to run the seeding script
- Bump @types/node dependency from 24.0.13 to 24.1.0