### PR TITLE
更新區域模型以允許可空的 area_name；新增 updateDevice 方法和路由以進行裝置更新

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model device {
 
 model area {
   area_id   Int      @id @default(autoincrement())
-  area_name String   @db.VarChar(100)
+  area_name String?  @db.VarChar(100)
   boundary  Json?
   devices   device[] @relation("AreaToDevice")
 }

--- a/src/controllers/area.controller.ts
+++ b/src/controllers/area.controller.ts
@@ -50,10 +50,6 @@ async getAllAreas(req: Request, res: Response): Promise<void> {
         };
     });
 
-    if (process.env.NODE_ENV !== 'production') {
-        console.log("樣區:", areasWithCircles);
-    }
-
     return successResponse(res, RESPONSE_CODE.SUCCESS, areasWithCircles);
 }
 
@@ -81,7 +77,7 @@ async getAllAreas(req: Request, res: Response): Promise<void> {
             const newArea = await prisma.area.create({
                 data: {
                     area_id: parsedAreaId,
-                    area_name: `${areaName || "未命名樣區"}`,
+                    area_name: areaName,
                 },
             });
             return successResponse(

--- a/src/controllers/coordinates.controller.ts
+++ b/src/controllers/coordinates.controller.ts
@@ -132,6 +132,7 @@ export class CoordinatesController {
                 area_id: true,
                 latitude: true,
                 longitude: true,
+                location_description: true,
             },
         });
         if (device) {
@@ -165,7 +166,6 @@ export class CoordinatesController {
             Array.isArray(boundary.coordinates?.[0]) &&
             boundary.coordinates[0].length >= 3
         ) {
-            console.log("樣區邊界點數:", boundary.coordinates[0].length);
             return successResponse(res, RESPONSE_CODE.SUCCESS, boundary.coordinates[0]);
         } else {
             console.warn("邊界資料格式錯誤或不足以形成多邊形:", area.boundary);

--- a/src/controllers/device.controller.ts
+++ b/src/controllers/device.controller.ts
@@ -100,4 +100,29 @@ export class DeviceController extends CoordinatesController {
             "刪除裝置失敗"
         );
     }
+
+    async updateDevice(req: Request, res: Response): Promise<void> {
+        const deviceId = parseInt(req.params.deviceId, 10);
+        const areaId = parseInt(req.params.areaId, 10);
+        const { deviceName } = req.body;
+        console.log("更新設備:", deviceId, "樣區:", areaId, "名稱:", deviceName);
+        try {
+            const device = await prisma.device.findUnique({
+                where: { device_id_area_id: { device_id: deviceId, area_id: areaId } },
+            });
+            if (!device) {
+                return errorResponse(res, RESPONSE_CODE.NOT_FOUND, "設備不存在");
+            }
+
+            const updatedDevice = await prisma.device.update({
+                where: { device_id_area_id: { device_id: deviceId, area_id: areaId } },
+                data: {
+                    device_name: deviceName,
+                },
+            });
+            return successResponse(res, RESPONSE_CODE.SUCCESS, updatedDevice, "設備更新成功");
+        } catch (error) {
+            return errorResponse(res, RESPONSE_CODE.INTERNAL_SERVER_ERROR, "設備更新失敗");
+        }
+    }
 }

--- a/src/routes/device.route.ts
+++ b/src/routes/device.route.ts
@@ -8,9 +8,10 @@ deviceRouter.route('/')
     .get(controller.getAllDevice.bind(controller))
     .post(controller.createDevice.bind(controller));
 
-deviceRouter.route('/:deviceId') // 不允許直接更新設備資料
+deviceRouter.route('/:deviceId')
     .get(controller.getDevice.bind(controller))
-    .delete(controller.deleteDevice.bind(controller));
+    .delete(controller.deleteDevice.bind(controller))
+    .patch(controller.updateDevice.bind(controller));
 
 
 deviceRouter.route('/:deviceId/coordinates')


### PR DESCRIPTION
## Summary by Sourcery

Introduce a PATCH endpoint for updating devices, make area_name optional in area creation, include location_description in coordinate responses, and remove extraneous debug logging.

New Features:
- Add updateDevice method and PATCH route to allow device name updates

Enhancements:
- Allow area_name to be nullable and remove default naming fallback
- Include location_description in coordinate retrieval responses
- Remove development-only console logs from area and coordinates controllers